### PR TITLE
relicense grandcentrix code to MIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 if(CONFIG_COBS)
 

--- a/fuzz/decode_compare/CMakeLists.txt
+++ b/fuzz/decode_compare/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.20.0)
 

--- a/fuzz/encode_compare/CMakeLists.txt
+++ b/fuzz/encode_compare/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.20.0)
 

--- a/include/cobs/stream.h
+++ b/include/cobs/stream.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: MIT */
 
 #ifndef COBS_STREAM_H_
 #define COBS_STREAM_H_

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 set -xeuo pipefail
 

--- a/stream.c
+++ b/stream.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: MIT */
 
 #include <errno.h>
 #include <stddef.h>

--- a/tests/cobs/CMakeLists.txt
+++ b/tests/cobs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/testutils/CMakeLists.txt
+++ b/testutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 find_package(Python3 REQUIRED COMPONENTS Development)
 

--- a/testutils/common.c
+++ b/testutils/common.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: MIT */
 
 #include <cobs/testutils.h>
 

--- a/testutils/include/cobs/testutils.h
+++ b/testutils/include/cobs/testutils.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/* SPDX-License-Identifier: MIT */
 
 #ifndef COBS_TESTUTILS_H
 #define COBS_TESTUTILS_H

--- a/west-ci.yml
+++ b/west-ci.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 manifest:
   remotes:


### PR DESCRIPTION
This lines up with the new license of the original COBS code.